### PR TITLE
[Feat] 파싱 \r\n 처리를 위한 함수 추가 #3

### DIFF
--- a/srcs/message/IRCMessage.hpp
+++ b/srcs/message/IRCMessage.hpp
@@ -6,7 +6,6 @@
 
 struct IRCMessage
 {
-	std::string prefix;
 	std::string command;
 	std::vector<std::string> parameters;
 	std::string trailing;

--- a/srcs/message/IRCMessageParser.hpp
+++ b/srcs/message/IRCMessageParser.hpp
@@ -12,16 +12,35 @@ class IRCMessageParser
 		static std::list<IRCMessage> parse(const char* requests)
 		{
 			std::list<IRCMessage> IRCMessages;
-			std::string request;
+			std::vector<std::string> messages;
 
-			std::istringstream iss(requests);
-
-			while(std::getline(iss, request, '\n'))
+			messages = split(requests, "\r\n");
+			for (std::vector<std::string>::const_iterator it = messages.begin(); it != messages.end(); ++it)
 			{
-				IRCMessages.push_back(parseMessage(request));
+				IRCMessages.push_back(parseMessage(*it));
 			}
 
 			return IRCMessages;
+		}
+	
+		static std::vector<std::string> split(const std::string& str, const std::string& delimiter) 
+		{
+			std::vector<std::string> tokens;
+			std::string::size_type pos = 0;
+
+			while (pos != std::string::npos)
+			{
+					std::string::size_type end = str.find(delimiter, pos);
+					if (end == std::string::npos) 
+					{
+							tokens.push_back(str.substr(pos));
+							break;
+					}
+					tokens.push_back(str.substr(pos, end - pos));
+					pos = end + delimiter.size();
+			}
+
+			return tokens;
 		}
 
 	private:

--- a/srcs/message/IRCMessageParser.hpp
+++ b/srcs/message/IRCMessageParser.hpp
@@ -51,13 +51,6 @@ class IRCMessageParser
 			std::string params;
 			std::string token;
 
-
-			if (request[0] == ':')
-			{
-				ss.ignore(1);
-				std::getline(ss, msg.prefix, ' ');
-			}
-
 			std::getline(ss, msg.command, ' ');
 
 			std::getline(ss, params, ':');

--- a/srcs/session/Session.cpp
+++ b/srcs/session/Session.cpp
@@ -22,7 +22,6 @@ void Session::onReadable()
 		std::cout << "\"" << _buffer <<"\"" << std::endl;
 		for (std::list<IRCMessage>::iterator it = _messages.begin(); it != _messages.end(); it++)
 		{
-			std::cout << "- prefix: " << it->prefix << std::endl;
 			std::cout << "- command: " << it->command << std::endl;
 			std::cout << "- parameters[" <<  it->parameters.size() << "]: ";
 			for (std::vector<std::string>::iterator iter = it->parameters.begin(); iter != it->parameters.end(); ++iter)

--- a/test/parse.cpp
+++ b/test/parse.cpp
@@ -12,13 +12,32 @@ struct IRCMessage {
 
 class IRCMessageParser {
 	public:
-		static IRCMessage parse(const char *request)
+		static std::vector<std::string> split(const std::string& str, const std::string& delimiter) 
+		{
+			std::vector<std::string> tokens;
+			std::string::size_type pos = 0;
+
+			while (pos != std::string::npos)
+			{
+					std::string::size_type end = str.find(delimiter, pos);
+					if (end == std::string::npos) 
+					{
+							tokens.push_back(str.substr(pos));
+							break;
+					}
+					tokens.push_back(str.substr(pos, end - pos));
+					pos = end + delimiter.size();
+			}
+
+			return tokens;
+		}
+	
+		static IRCMessage parse(std::string &request)
 		{
 			IRCMessage msg;
 			std::istringstream ss(request);
 			std::string params;
 			std::string token;
-
 
 			if (request[0] == ':')
 			{
@@ -45,29 +64,30 @@ class IRCMessageParser {
 int main()
 {
 	const char *packets[] = {
-			"PASS <password> (optional)",
-			"NICK <nickname>",
-			"USER <username> <hostname> <servername> <realname>",
-			"JOIN <channel>",
-			"PRIVMSG <target> <message>",
-			"PART <channel>",
+			"PASS <password> (optional)\r\n",
+			"NICK <nickname>\r\n",
+			"USER <username> <hostname> <servername> <realname>\r\n",
+			"JOIN <channel>,<channel> <key>\r\n",
+			"PRIVMSG <target> <message>\r\n",
+			"PART <channel>\r\n",
 			"",
-			":prefix command param1 param2 :trailing",
-			":prefix command param1 param2 :trailing  with   spaces ",
+			":prefix command param1 param2 :trailing\r\n",
+			":prefix command param1 param2 :trailing  with   spaces \r\n",
 			":prefix\r\n",
 	};
 
 	for(const char *packet : packets){
-		IRCMessage msg = IRCMessageParser::parse(packet);
+		std::vector<std::string> msgs = IRCMessageParser::split(packet, "\r\n");
+		IRCMessage msg = IRCMessageParser::parse(msgs[0]);
 		std::cout << "\"" << packet <<"\"" << std::endl;
 		std::cout << "- prefix: " << msg.prefix << std::endl;
 		std::cout << "- command: " << msg.command <<  std::endl;
-		std::cout << "- parameters[" <<  msg.parameters.size() << "]: ";
+		std::cout << "- parameters[" <<  msg.parameters.size() << "]: [";
 		for (std::string param : msg.parameters) {
-			std::cout << param << " ";
+			std::cout << param << "| ";
 		}
-		std::cout << "\n";
-		std::cout << "- traling: " << msg.trailing << "\\*"<< std::endl;
+		std::cout << "]\n";
+		std::cout << "- traling: " << msg.trailing << "|END."<< std::endl;
 		std::cout << std::endl;
 	}
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  -  파싱 \r\n 처리를 위한 split 함수 추가
  - prefix 삭제
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 명령어 끝에 항상 \r\n가 들어옴!
  - \r\n 처리를 위해 split 함수 추가함 
  - 나중에 혹시 또 쓸 데가 있을 것 같아 split 함수로 만들었습니다~!! 
  - prefix는 parser에서는 쓰지 않아서 삭제했습니다! (서버에서 클라이언트로 보낼 때 쓰는 것!)

 
