### PR TITLE
[Fix] SesssionIndex를 활용한 Send함수 수정#14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ SRCS = ./srcs/main.cpp \
 	./srcs/session/Session.cpp \
 	./srcs/session/SessionManager.cpp \
 	./srcs/packet/PacketManager.cpp \
+	./srcs/message/IRCMessage.cpp \
 	./srcs/client/ClientManager.cpp \
 	./srcs/client/Client.cpp \
 	./srcs/channel/ChannelManager.cpp \
-	./srcs/channel/Channel.cpp 
+	./srcs/channel/Channel.cpp
+
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/srcs/packet/PacketManager.hpp
+++ b/srcs/packet/PacketManager.hpp
@@ -7,23 +7,26 @@
 #include "../message/IRCMessage.hpp"
 #include "../channel/ChannelManager.hpp"
 #include "../client/ClientManager.hpp"
+#include "../session/SessionManager.hpp"
 
 class PacketManager
 {
 	public:
 		void init();
-		void process(int clientSocket, int sessionIndex, IRCMessage &req);
+		void process(int sessionIndex, IRCMessage &req);
 
-		void processDisconnect(int clientSocket, int sessionIndex, IRCMessage &req);
-		void processNick(int clientSocket, int sessionIndex, IRCMessage &req);
-		void processPass(int clientSocket, int sessionIndex, IRCMessage &req);
-		void processUser(int clientSocket, int sessionIndex, IRCMessage &req);
-		void processPing(int clientSocket, int sessionIndex, IRCMessage &req);
+		//void broadcastJoinChannels(int sessionIndex, IRCMessage &message);
+		void processDisconnect(int sessionIndex, IRCMessage &req);
+		void processNick(int sessionIndex, IRCMessage &req);
+		void processPass(int sessionIndex, IRCMessage &req);
+		void processUser(int sessionIndex, IRCMessage &req);
+		void processPing(int sessionIndex, IRCMessage &req);
 
+		static void(*_sendPacketFunc)(int sessionIndex, std::string &res);
 	private:
 		ClientManager _clientManager;
 		ChannelManager _channelManager;
-		typedef void(PacketManager::* PROCESS_RECV_PACKET_FUNCTION)(int, int, IRCMessage&);
+		typedef void(PacketManager::* PROCESS_RECV_PACKET_FUNCTION)(int, IRCMessage&);
 
 		std::map<std::string, PROCESS_RECV_PACKET_FUNCTION> _recvFuntionDictionary;
 };

--- a/srcs/server/IRCServer.cpp
+++ b/srcs/server/IRCServer.cpp
@@ -66,7 +66,7 @@ void IRCServer::process()
 {
 	for(std::deque<RecvPacketInfo>::iterator it = _packetQueue.begin(); it != _packetQueue.end(); ++it)
 	{
-		_packetManager.process(it->clientSocket, it->sessionIndex, it->message);
+		_packetManager.process(it->sessionIndex, it->message);
 		if (it->message._command == "DISCONNECT")
 		{
 			_sessionManager.unRegisterSession(it->sessionIndex);
@@ -75,8 +75,8 @@ void IRCServer::process()
 	_packetQueue.clear();
 }
 
-void IRCServer::addPacketFunc(int clientSocket, int sessionIndex, IRCMessage &message)
+void IRCServer::addPacketFunc(int sessionIndex, IRCMessage &message)
 {
-	RecvPacketInfo packetInfo = {clientSocket, sessionIndex, message};
+	RecvPacketInfo packetInfo = {sessionIndex, message};
 	_packetQueue.push_back(packetInfo);
 }

--- a/srcs/server/IRCServer.hpp
+++ b/srcs/server/IRCServer.hpp
@@ -17,7 +17,7 @@ class IRCServer
 		void init(int port, char *password);
 		void start();
 
-		static void addPacketFunc(int clientSocket, int sessionIndex, IRCMessage &message);
+		static void addPacketFunc(int sessionIndex, IRCMessage &message);
 
 	private:
 		void onRequestHandler(int socket);

--- a/srcs/session/Session.cpp
+++ b/srcs/session/Session.cpp
@@ -1,6 +1,6 @@
 #include "Session.hpp"
 
-void (*Session::_addPacketFunc)(int, int, IRCMessage&) = 0;
+void (*Session::_addPacketFunc)(int, IRCMessage&) = 0;
 
 Session::Session(int sessionIndex, int clientSocket) : _sessionIndex(sessionIndex), _clientSocket(clientSocket)
 {
@@ -38,7 +38,7 @@ void Session::onReadable()
 			std::cout << "\n";
 			std::cout << "- traling: " << it->_trailing << std::endl;
 			std::cout << std::endl;
-			_addPacketFunc(_clientSocket, _sessionIndex, *it);
+			_addPacketFunc(_sessionIndex, *it);
 		}
 	}
 }
@@ -49,10 +49,15 @@ void Session::close()
 	message._command = "DISCONNECT";
 	_messages.push_back(message);
 
-	_addPacketFunc(_clientSocket, _sessionIndex, _messages.front());
+	_addPacketFunc(_sessionIndex, _messages.front());
 }
 
 int Session::getClientSocket()
 {
 	return _clientSocket;
+}
+
+void Session::sendPacket(std::string &res)
+{
+	send(_clientSocket, res.c_str(), res.size(), 0);
 }

--- a/srcs/session/Session.hpp
+++ b/srcs/session/Session.hpp
@@ -15,10 +15,11 @@ class Session
 		~Session();
 
 		void onReadable();
+		void sendPacket(std::string&);
 
 		int getClientSocket();
 
-		static void(*_addPacketFunc)(int, int, IRCMessage&);
+		static void(*_addPacketFunc)(int, IRCMessage&);
 
 	private :
 		void close();
@@ -27,7 +28,6 @@ class Session
 		std::list<IRCMessage> _messages;
 		int _sessionIndex;
 		int _clientSocket;
-		PacketManager _packetManager;
 };
 
 #endif

--- a/srcs/session/SessionManager.cpp
+++ b/srcs/session/SessionManager.cpp
@@ -1,5 +1,7 @@
 #include "SessionManager.hpp"
 
+std::vector<Session*> SessionManager::_sessions = std::vector<Session*>();
+
 SessionManager::SessionManager()
 {
 	for (int i = 0; i < 1024; ++i)
@@ -35,7 +37,7 @@ void SessionManager::unRegisterSession(int sessionIndex)
 {
 	freeSessionIndex(sessionIndex);
 	_sessionIndexMap.erase(_sessions[sessionIndex]->getClientSocket());
-	
+
 	delete _sessions[sessionIndex];
 	_sessions[sessionIndex] = 0;
 }
@@ -69,3 +71,9 @@ Session* SessionManager::getSessionBySocket(int clientSocket)
 	int sessionIndex = _sessionIndexMap[clientSocket];
 	return _sessions[sessionIndex];
 }
+
+void SessionManager::sendPacketFunc(int sessionIndex, std::string &res)
+{
+	_sessions[sessionIndex]->sendPacket(res);
+}
+

--- a/srcs/session/SessionManager.hpp
+++ b/srcs/session/SessionManager.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include "Session.hpp"
 
+class Session;
+
 class SessionManager {
 	public:
 		SessionManager();
@@ -19,9 +21,11 @@ class SessionManager {
 
 		Session*  getSessionBySocket(int clientSocket);
 
+		static void sendPacketFunc(int sessionIndex, std::string &res);
+
 	private:
 		std::map<int, int> _sessionIndexMap;
-		std::vector<Session*> _sessions;
+		static std::vector<Session*> _sessions;
 		std::deque<int> _sessionIndexPool;
 };
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 기존의 PacketManager에서  send()로 브로드캐스트를 구현하기 위해서는 Client객체들이 자신의 fd를 가져야했습니다. 
    (현재는 각 클라이언트들이 fd를 저장하지 않음)
  - 이를 해결하기 위해 PacketManager에서 Socket대신 SessionIndex를 통해 클라이언트에게 데이터를 보낼 수 있도록 수정하였습니다.
  
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 다음이 수정되었습니다.
     - PacketManager에서 `clientSocket` 매개변수가 사라졌습니다. 이로 인해 관련된 헤더파일들이 모두 수정되었습니다.
     - PacketManager에서 send() 대신  `_sendPacketFunc()` 사용으로 변경되어습니다.
     - PacketManager에서 `ProccessNick()`, `broadcastJoinChannels()`은 계속 작업 중입니다.
   

 
