### PR TITLE
[Fix] make 안 되는 문제 해결 및 split 끝이 구분자 아닐 경우 해결

### DIFF
--- a/srcs/message/IRCMessage.cpp
+++ b/srcs/message/IRCMessage.cpp
@@ -24,6 +24,10 @@ std::list<std::string> IRCMessage::split(const std::string& str, const std::stri
 			std::string::size_type end = str.find(delimiter, pos);
 			if (end == std::string::npos)
 			{
+				if (str.size() != pos)
+				{
+					tokens.push_back(str.substr(pos));
+				}
 				break;
 			}
 			tokens.push_back(str.substr(pos, end - pos));

--- a/srcs/packet/Packet.hpp
+++ b/srcs/packet/Packet.hpp
@@ -5,7 +5,6 @@
 
 struct RecvPacketInfo
 {
-	int clientSocket;
 	int sessionIndex;
 	IRCMessage &message;
 };


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - make 안 되는 문제 해결 및 split 끝이 구분자 일 경우 해결
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - RecvPacketInfo 수정사항 반영되어 있지 않아 make 안 되는 문제 해결
  - split 끝이 구분자가 아닐 경우에도 잘 처리할 수 있도록 수정
  - (🤔) 요소가 추가될 때, vector보다 list가 메모리 면에서 낫다는 의견이 있어 vector -> list 로 수정했는데요!
    사실 split한 요소는 iterator로 접근하며 사용하는데, 메모리가 연속적으로 할당되는 vector가 더 낫지 않을까 생각되네요!(다들 어찌 생각하는지!)

 
